### PR TITLE
Pimp xx refactor chat component

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { MessageService } from "./services/message.service";
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
-  providers: [MessageService]
+  providers: [MessageService, AuthService]
 })
 export class AppComponent {
   title = 'PIMP';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,20 +1,24 @@
 import { Component } from '@angular/core';
 import { Router } from "@angular/router";
 import { AuthService } from "./services/auth.service";
+import { MessageService } from "./services/message.service";
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  styleUrls: ['./app.component.css'],
+  providers: [MessageService]
 })
 export class AppComponent {
   title = 'PIMP';
   router: Router;
   authService: AuthService;
+  messageService: MessageService;
 
-  constructor(router: Router, authService: AuthService) {
+  constructor(router: Router, authService: AuthService, messageService: MessageService) {
     this.router = router;
     this.authService = authService;
+    this.messageService = messageService;
   }
 
   logout() {

--- a/src/app/chat/chat.component.html
+++ b/src/app/chat/chat.component.html
@@ -1,7 +1,11 @@
-<li *ngFor='let message of messages'>
-  <u>{{message.date}} {{message.userName}} : {{ message.message }}</u>
+<li *ngFor='let message of currentMessages'>
+  <ul>{{message.date}} {{message.userName}} : {{ message.message }}</ul>
 </li>
-<form (ngSubmit)="send()">
+<form (ngSubmit)="send()" style="margin: 10px 0">
   <input type="text" [(ngModel)]="text" class="form-control"
     placeholder="Enter message..." [ngModelOptions]="{standalone: true}">
 </form>
+<span>Change room: </span>
+<span *ngFor='let room of rooms' (click)="changeRoom(room)">
+  <button>{{room}}</button>
+</span>

--- a/src/app/chat/chat.component.html
+++ b/src/app/chat/chat.component.html
@@ -6,6 +6,6 @@
     placeholder="Enter message..." [ngModelOptions]="{standalone: true}">
 </form>
 <span>Change room: </span>
-<span *ngFor='let room of rooms' (click)="changeRoom(room)">
+<span *ngFor='let room of rooms' (click)="setCurrentRoom(room)">
   <button>{{room}}</button>
 </span>

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -1,34 +1,39 @@
 import { Component, OnInit } from '@angular/core';
 import { MessageService } from '../services/message.service';
+import { Message, MessageCollection } from '../models/message';
 
 @Component({
   selector: 'app-chat',
   templateUrl: './chat.component.html',
-  styleUrls: ['./chat.component.css'],
-  providers: [MessageService]
+  styleUrls: ['./chat.component.css']
 })
 export class ChatComponent implements OnInit {
-  roomId: any;
-  text: any;
+  currentRoom: string;
+  text: string;
+  messages: MessageCollection;
+  currentMessages: Message[];
+  rooms: String[];
   messageService: MessageService;
-  messages: Array<String> = new Array<String>();
 
   constructor(messageService: MessageService) {
     this.messageService = messageService;
-    this.roomId = "general"
+    this.currentRoom = messageService.getRoomId();
+    this.rooms = messageService.getRooms();
   }
 
   send() {
-    this.messageService.publish(this.roomId, this.text);
+    this.messageService.publish(this.currentRoom, this.text);
     this.text = "";
   }
 
   ngOnInit() {
-    let callback = (message: any) => {
-      let convertedMessage = JSON.parse(message);
-      convertedMessage['date'] = new Date();
-      this.messages.push(convertedMessage);
-    }
-    this.messageService.subscribe(this.roomId, callback);
+    this.messages = this.messageService.getMessages();
+    this.currentMessages = this.messages[this.currentRoom];
+  }
+
+  changeRoom(room) {
+    this.messageService.setRoomId(room);
+    this.currentRoom = room;
+    this.currentMessages = this.messages[room];
   }
 }

--- a/src/app/chat/chat.component.ts
+++ b/src/app/chat/chat.component.ts
@@ -17,7 +17,7 @@ export class ChatComponent implements OnInit {
 
   constructor(messageService: MessageService) {
     this.messageService = messageService;
-    this.currentRoom = messageService.getRoomId();
+    this.currentRoom = messageService.getCurrentRoom();
     this.rooms = messageService.getRooms();
   }
 
@@ -31,8 +31,8 @@ export class ChatComponent implements OnInit {
     this.currentMessages = this.messages[this.currentRoom];
   }
 
-  changeRoom(room) {
-    this.messageService.setRoomId(room);
+  setCurrentRoom(room) {
+    this.messageService.setCurrentRoom(room);
     this.currentRoom = room;
     this.currentMessages = this.messages[room];
   }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
+import { MessageService } from '../services/message.service';
 import { User } from "../models/user";
 import { Router } from "@angular/router";
 
@@ -12,10 +13,12 @@ import { Router } from "@angular/router";
 export class LoginComponent implements OnInit {
   private router: Router;
   private authService: AuthService;
+  private messageService: MessageService;
   user: User = new User();
   error: String;
-  constructor(authService: AuthService, router: Router) {
+  constructor(authService: AuthService, router: Router, messageService: MessageService) {
     this.authService = authService;
+    this.messageService = messageService;
     this.router = router;
   }
 
@@ -27,6 +30,7 @@ export class LoginComponent implements OnInit {
       .subscribe(result => {
         if (result === true) {
           this.router.navigate(['profile']);
+          this.messageService.init();
         } else {
           this.error = 'Username or password is incorrect';
         }

--- a/src/app/models/message.ts
+++ b/src/app/models/message.ts
@@ -1,0 +1,10 @@
+export class Message {
+  date: Date
+  userName; String
+  message: String
+}
+
+// holds messages of all rooms
+export interface MessageCollection {
+  [room:string]: Message[]
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -45,5 +45,9 @@ export class AuthService {
     return this.token != null;
   }
 
+  getToken(): string {
+    return this.token;
+  }
+
 }
 

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -1,38 +1,91 @@
 import { Injectable } from '@angular/core';
 import * as SockJS from 'sockjs-client';
 import * as Stomp from 'stompjs';
+import { Message, MessageCollection } from '../models/message';
 
 @Injectable()
 export class MessageService {
+
   stompClient: any;
-  session: any;
-  sessionPool: {}
+  sessionPool: {};
+  currentRoom = "general";
+
+  messages: MessageCollection = {};
+  rooms: string[] = [];
 
   constructor() {
-    let token = JSON.parse(localStorage.getItem('currentUser')).token;
-    let socket = new SockJS('http://localhost:8080/chat/' + '?access_token=' + token);
-    this.stompClient = Stomp.over(socket);
+    /*
+    Each room in the `message: MessageCollection` must be initialized with an empty array,
+    otherwise Angular does not pick up changes in this nested data structure.
+    Need to find out how it behaves when a room is added dynamically.
+    */
+    this.getInitialRooms().then( (rooms: string[]) => {
+
+      let token = JSON.parse(localStorage.getItem('currentUser')).token;
+      // TODO: move url to config. might be different on production
+      let socket = new SockJS('http://localhost:8080/chat/' + '?access_token=' + token);
+      this.stompClient = Stomp.over(socket);
+      this.stompClient.debug = null;
+
+      for(let room of rooms) {
+        this.rooms.push(room);
+        this.messages[room] = [];
+      }
+
+      this.subscribe(rooms);
+    } );
   }
 
-  publish(roomId: String, message: String) {
+  /* Get all rooms in which user is member */
+  getInitialRooms() {
+    return new Promise( (resolve, reject) => {
+      // Make HTTP call when the endpoint is implemented
+      resolve( [this.currentRoom, "watercooler", "beer"] );
+    });
+  }
+
+  publish(roomId: String, message: string) {
+    console.log("Publishing room " + roomId)
     let userName = JSON.parse(localStorage.getItem('currentUser')).username;
     this.stompClient.send('/app/broker/' + roomId, {},
       JSON.stringify({
-        'message': message,
-        'roomId': roomId,
-        'userName': userName
+        message,
+        roomId,
+        userName
       }));
   }
 
-  subscribe(roomId: String, callback: (string) => any) {
+  subscribe(rooms: string[]) {
     var that = this;
-    let session = this.stompClient.connect({}, function (frame) {
-        that.stompClient.subscribe('/rooms/message/' + roomId, function (message) {
-          callback(message.body);
+    this.stompClient.connect({}, (frame) => {
+        for(let roomId of rooms) {
+          that.stompClient.subscribe('/rooms/message/' + roomId, function ( { body } ) {
+          let message: Message = JSON.parse(body);
+          // The timestamp should come from the server to prevent timezone issues
+          message.date = new Date();
+          that.messages[roomId].push(message);
         });
-    }, function (err) {
+        }
+        
+    }, (err) => {
         console.log('err', err);
     });
+  }
+
+  getMessages() {
+    return this.messages;
+  }
+
+  getRoomId() {
+    return this.currentRoom;
+  }
+
+  setRoomId(room) {
+    this.currentRoom = room;
+  }
+
+  getRooms() {
+    return this.rooms;
   }
 
 }


### PR DESCRIPTION
Did some refactoring of the chat component. Moving the MessageService out of the chat component into the root component is necessary as constructor and onInit are called on every route change reinitializing the websocket connection. The component gets basically destroyed when leaving the route, thus it must be stateless. It's state now lives in MessageService. 

Basic multiroom feature is working. I added some hardcoded rooms to demonstrate. As soon as the REST endpoint for fetching all rooms the user is member of, this can be replaced with a proper HTTP call.